### PR TITLE
[Feat] Chat Entity,VO, Enum 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,5 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,java,gradle,intellij+all,visualstudiocode
+
+generated/

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,9 @@ ext {
 
 dependencies {
 
-	// PostgreSQL
+	// Database
 	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'com.h2database:h2'
 
 	// common 공통 모듈
 	implementation 'org.pgsg:common:0.0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -45,16 +45,39 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	// QueryDSL
+	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.8:jpa'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-//	kafka
-//	implementation 'org.springframework.kafka:spring-kafka'
-//	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+
+	// test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+	delete querydslDir
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,13 @@ java {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://maven.pkg.github.com/89-49/common")
+		credentials {
+			username = findProperty('gpr.user') ?: System.getenv('GPR_USER')
+			password = findProperty('gpr.token') ?: System.getenv('GPR_TOKEN')
+		}
+	}
 }
 
 ext {
@@ -22,21 +29,15 @@ ext {
 }
 
 dependencies {
-	// JPA
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// PostgreSQL
+	runtimeOnly 'org.postgresql:postgresql'
 
-	// REST API
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// common 공통 모듈
+	implementation 'org.pgsg:common:0.0.1-SNAPSHOT'
 
 	// STOMP WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
-	// Eureka Client
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -44,15 +45,10 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
-	// PostgreSQL
-	runtimeOnly 'org.postgresql:postgresql'
 
-	// test
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	//  kafka
-	//	implementation 'org.springframework.kafka:spring-kafka'
-	//	testImplementation 'org.springframework.kafka:spring-kafka-test'
+//	kafka
+//	implementation 'org.springframework.kafka:spring-kafka'
+//	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/src/main/java/org/pgsg/chat/ChatApplication.java
+++ b/src/main/java/org/pgsg/chat/ChatApplication.java
@@ -2,8 +2,9 @@ package org.pgsg.chat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-
+@EnableJpaAuditing
 @SpringBootApplication
 public class ChatApplication {
 

--- a/src/main/java/org/pgsg/chat/ChatApplication.java
+++ b/src/main/java/org/pgsg/chat/ChatApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class ChatApplication {
 

--- a/src/main/java/org/pgsg/chat/domain/event/ChatEvents.java
+++ b/src/main/java/org/pgsg/chat/domain/event/ChatEvents.java
@@ -1,0 +1,8 @@
+package org.pgsg.chat.domain.event;
+
+import org.pgsg.chat.domain.model.ChatRoom;
+
+public interface ChatEvents {
+    void completed(ChatRoom room);
+    void canceled(ChatRoom room);
+}

--- a/src/main/java/org/pgsg/chat/domain/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/org/pgsg/chat/domain/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,7 @@
+package org.pgsg.chat.domain.exception;
+
+public class ChatRoomNotFoundException extends ChatServiceException{
+    public ChatRoomNotFoundException() {
+        super("ChatRoomNotFoundException");
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/exception/ChatServiceException.java
+++ b/src/main/java/org/pgsg/chat/domain/exception/ChatServiceException.java
@@ -1,0 +1,13 @@
+package org.pgsg.chat.domain.exception;
+
+import org.pgsg.common.exception.CustomException;
+
+public class ChatServiceException extends CustomException {
+
+    public ChatServiceException(String errorName){
+        this(errorName,null);
+    }
+    public ChatServiceException(String errorName, String field){
+        super(errorName,field);
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/exception/InvalidTradeIdException.java
+++ b/src/main/java/org/pgsg/chat/domain/exception/InvalidTradeIdException.java
@@ -1,0 +1,7 @@
+package org.pgsg.chat.domain.exception;
+
+public class InvalidTradeIdException extends ChatServiceException {
+    public InvalidTradeIdException() {
+        super("InvalidTradeIdException");
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/model/Buyer.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Buyer.java
@@ -1,0 +1,37 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.pgsg.chat.domain.exception.ChatServiceException;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@ToString
+@Embeddable
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class Buyer {
+
+    @Column(name = "buyer_member_id", nullable = false)
+    private UUID id;
+
+    @Column(name = "buyer_nickname", nullable = false)
+    private String nickname;
+
+    protected Buyer(UUID id, String nickname) {
+        if (id == null) {
+            throw new ChatServiceException("InvalidBuyerIdException");
+        }
+
+        if (!StringUtils.hasText(nickname)) {
+            throw new ChatServiceException("InvalidBuyerNicknameException");
+        }
+        this.id = id;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/model/ChatMessage.java
+++ b/src/main/java/org/pgsg/chat/domain/model/ChatMessage.java
@@ -1,0 +1,42 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SenderType senderType;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    public static ChatMessage of(SenderType type, String content) {
+        ChatMessage chatMessage = new ChatMessage();
+        chatMessage.senderType = type;
+        chatMessage.content = content;
+        return chatMessage;
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/model/ChatMessage.java
+++ b/src/main/java/org/pgsg/chat/domain/model/ChatMessage.java
@@ -4,8 +4,10 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.pgsg.chat.domain.exception.ChatServiceException;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -34,6 +36,13 @@ public class ChatMessage {
     private LocalDateTime createdAt;
 
     public static ChatMessage of(SenderType type, String content) {
+        if(type ==null){
+            throw new ChatServiceException("InvalidSenderTypeException");
+        }
+
+        if(!StringUtils.hasText(content)){
+            throw new ChatServiceException("EmptyChatMessageException");
+        }
         ChatMessage chatMessage = new ChatMessage();
         chatMessage.senderType = type;
         chatMessage.content = content;

--- a/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
+++ b/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 import org.pgsg.chat.domain.event.ChatEvents;
+import org.pgsg.chat.domain.exception.ChatServiceException;
 import org.pgsg.common.domain.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -64,6 +65,9 @@ public class ChatRoom extends BaseEntity {
         if(this.status == RoomStatus.COMPLETED){ // 이미 완료 상태이면 처리 X, 멱등성 처리
             return;
         }
+        if(this.status == RoomStatus.CANCELED){
+            throw new ChatServiceException("InvalidRoomStatusTransitionException");
+        }
 
         this.status = RoomStatus.COMPLETED;
 
@@ -75,6 +79,9 @@ public class ChatRoom extends BaseEntity {
     public void cancel(ChatEvents events) {
         if(this.status == RoomStatus.CANCELED){ // 이미 취소 상태이면 처리 X, 멱등성 처리
             return;
+        }
+        if(this.status == RoomStatus.COMPLETED){
+            throw new ChatServiceException("InvalidRoomStatusTransitionException");
         }
         this.status = RoomStatus.CANCELED;
 

--- a/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
+++ b/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
@@ -52,6 +52,9 @@ public class ChatRoom extends BaseEntity {
 
     // 채팅 메세지 등록
     public void addMessage(SenderType type, String content){
+        if(this.status != RoomStatus.TRADING){
+            throw new ChatServiceException("InvalidRoomStatusTransitionException");
+        }
         this.messages.add(ChatMessage.of(type, content));
     }
 

--- a/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
+++ b/src/main/java/org/pgsg/chat/domain/model/ChatRoom.java
@@ -1,0 +1,84 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+import org.pgsg.chat.domain.event.ChatEvents;
+import org.pgsg.common.domain.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@ToString
+@Table(name = "p_chat_room")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class ChatRoom extends BaseEntity {
+
+    @EmbeddedId
+    private RoomId id;
+
+    @Embedded
+    private Seller seller;
+
+    @Embedded
+    private Buyer buyer;
+
+    @Embedded
+    private Product product;
+
+    @Enumerated(EnumType.STRING)
+    private RoomStatus status;
+
+
+    @JoinColumn(name="chatroom_id")
+    @OrderBy("createdAt ASC")
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    @Builder
+    public ChatRoom(UUID tradeId,UUID productId, String productName, UUID sellerId,String sellerNickName,UUID buyerId,String buyerNickName) {
+        this.id = RoomId.of(tradeId);
+        this.seller = new Seller(sellerId, sellerNickName);
+        this.buyer = new Buyer(buyerId, buyerNickName);
+        this.product = new Product(productId, productName);
+        this.status = RoomStatus.TRADING;
+    }
+
+    // 채팅 메세지 등록
+    public void addMessage(SenderType type, String content){
+        this.messages.add(ChatMessage.of(type, content));
+    }
+
+    // 마지막 메세지 등록 일시
+    public LocalDateTime getLastMessageAt() {
+        return this.messages == null || this.messages.isEmpty() ? null : this.messages.getLast().getCreatedAt();
+    }
+
+    // 완료 상태 변경
+    public void complete(ChatEvents events) {
+        if(this.status == RoomStatus.COMPLETED){ // 이미 완료 상태이면 처리 X, 멱등성 처리
+            return;
+        }
+
+        this.status = RoomStatus.COMPLETED;
+
+        // 완료 상태 변경 후 후속 처리 알림
+        events.completed(this);
+    }
+
+    // 취소 상태 변경
+    public void cancel(ChatEvents events) {
+        if(this.status == RoomStatus.CANCELED){ // 이미 취소 상태이면 처리 X, 멱등성 처리
+            return;
+        }
+        this.status = RoomStatus.CANCELED;
+
+        // 취소 상태 변경 후 후속 처리 알림
+        events.canceled(this);
+    }
+ }

--- a/src/main/java/org/pgsg/chat/domain/model/Product.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Product.java
@@ -16,10 +16,10 @@ import java.util.UUID;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product {
-    @Column(length = 45, name="product_id")
+    @Column(length = 45, name="product_id", nullable = false)
     private UUID id;
 
-    @Column(length = 100, name="product_name")
+    @Column(length = 100, name="product_name", nullable = false)
     private String name;
 
     protected Product(UUID id, String name) {

--- a/src/main/java/org/pgsg/chat/domain/model/Product.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Product.java
@@ -1,0 +1,37 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.pgsg.chat.domain.exception.ChatServiceException;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@ToString
+@Embeddable
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+    @Column(length = 45, name="product_id")
+    private UUID id;
+
+    @Column(length = 100, name="product_name")
+    private String name;
+
+    protected Product(UUID id, String name) {
+        if (id == null) {
+            throw new ChatServiceException("InvalidProductIdException");
+        }
+
+        if (!StringUtils.hasText(name)) {
+            throw new ChatServiceException("InvalidProductNameException");
+        }
+
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/model/RoomId.java
+++ b/src/main/java/org/pgsg/chat/domain/model/RoomId.java
@@ -1,0 +1,25 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomId implements Serializable {
+
+    @Column
+    private UUID id;
+
+
+    public static RoomId of(UUID tradeId){
+        return new RoomId(tradeId);
+    }
+
+}

--- a/src/main/java/org/pgsg/chat/domain/model/RoomId.java
+++ b/src/main/java/org/pgsg/chat/domain/model/RoomId.java
@@ -3,6 +3,7 @@ package org.pgsg.chat.domain.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
+import org.pgsg.chat.domain.exception.InvalidTradeIdException;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -19,6 +20,9 @@ public class RoomId implements Serializable {
 
 
     public static RoomId of(UUID tradeId){
+        if(tradeId == null){
+            throw new InvalidTradeIdException();
+        }
         return new RoomId(tradeId);
     }
 

--- a/src/main/java/org/pgsg/chat/domain/model/RoomStatus.java
+++ b/src/main/java/org/pgsg/chat/domain/model/RoomStatus.java
@@ -1,0 +1,7 @@
+package org.pgsg.chat.domain.model;
+
+public enum RoomStatus {
+    TRADING,
+    COMPLETED,
+    CANCELED,
+}

--- a/src/main/java/org/pgsg/chat/domain/model/Seller.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Seller.java
@@ -1,0 +1,38 @@
+package org.pgsg.chat.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.pgsg.chat.domain.exception.ChatServiceException;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@ToString
+@Embeddable
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seller {
+
+    @Column(name = "seller_member_id", nullable = false)
+    private UUID id;
+
+    @Column(name = "seller_nickname", nullable = false)
+    private String nickname;
+
+    protected Seller(UUID id, String nickname) {
+        if (id == null) {
+            throw new ChatServiceException("InvalidSellerIdException");
+        }
+
+        if (!StringUtils.hasText(nickname)) {
+            throw new ChatServiceException("InvalidSellerNicknameException");
+        }
+
+        this.id = id;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/org/pgsg/chat/domain/model/SenderType.java
+++ b/src/main/java/org/pgsg/chat/domain/model/SenderType.java
@@ -1,0 +1,6 @@
+package org.pgsg.chat.domain.model;
+
+public enum SenderType {
+    SELLER,
+    BUYER
+}

--- a/src/main/java/org/pgsg/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/org/pgsg/chat/domain/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package org.pgsg.chat.domain.repository;
+
+import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.RoomId;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository {
+    ChatRoom save(ChatRoom room);
+    Optional<ChatRoom> findById(RoomId id);
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/event/ChatEventsImpl.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/event/ChatEventsImpl.java
@@ -1,0 +1,18 @@
+package org.pgsg.chat.infrastructure.event;
+
+import org.pgsg.chat.domain.event.ChatEvents;
+import org.pgsg.chat.domain.model.ChatRoom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatEventsImpl implements ChatEvents {
+    @Override
+    public void completed(ChatRoom room) {
+
+    }
+
+    @Override
+    public void canceled(ChatRoom room) {
+
+    }
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/persistence/JpaChatRoomRepository.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/persistence/JpaChatRoomRepository.java
@@ -1,0 +1,10 @@
+package org.pgsg.chat.infrastructure.persistence;
+
+import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.repository.ChatRoomRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaChatRoomRepository extends ChatRoomRepository, JpaRepository<ChatRoom, RoomId> {
+
+}

--- a/src/main/resources/application-error.yaml
+++ b/src/main/resources/application-error.yaml
@@ -1,0 +1,61 @@
+error:
+  configs:
+    ChatRoomNotFoundException:
+      code: "C001"
+      message: "채팅방을 찾을 수 없습니다."
+      status: 404
+
+    InvalidSellerIdException:
+      code: "C002"
+      message: "판매자의 id 값이 Null일 수 없습니다."
+      status: 400
+
+    InvalidBuyerIdException:
+      code: "C003"
+      message: "구매자의 id 값이 Null일 수 없습니다."
+      status: 400
+
+    InvalidProductIdException:
+      code: "C004"
+      message: "상품의 id 값이 Null일 수 없습니다."
+      status: 400
+
+    InvalidTradeIdException:
+      code: "C005"
+      message: "거래의 id 값이 Null일 수 없습니다."
+      status: 400
+
+    InvalidSellerNicknameException:
+      code: "C006"
+      message: "판매자의 이름이 Null일 수 없습니다."
+      status: 400
+
+    InvalidBuyerNicknameException:
+      code: "C007"
+      message: "구매자의 이름이 Null일 수 없습니다."
+      status: 400
+
+    InvalidProductNameException:
+      code: "C008"
+      message: "상품명이 Null일 수 없습니다."
+      status: 400
+
+    HasStatusCompleteException:
+      code: "C009"
+      message: "채팅방의 상태가 거래 완료입니다."
+      status: 400
+
+    HasStatusCancelException:
+      code: "C010"
+      message: "채팅방의 상태가 거래 취소입니다."
+      status: 400
+
+    EmptyChatMessageException:
+      code: "C011"
+      message: "메세지는 빈 상태로 보낼 수 없습니다."
+      status: 400
+
+    AlreadyChatRoomException:
+      code: "C012"
+      message: "이미 존재하는 채팅방 입니다."
+      status: 409

--- a/src/main/resources/application-error.yaml
+++ b/src/main/resources/application-error.yaml
@@ -52,10 +52,20 @@ error:
 
     EmptyChatMessageException:
       code: "C011"
-      message: "메세지는 빈 상태로 보낼 수 없습니다."
+      message: "메시지는 빈 상태로 보낼 수 없습니다."
       status: 400
 
     AlreadyChatRoomException:
       code: "C012"
       message: "이미 존재하는 채팅방 입니다."
       status: 409
+
+    InvalidSenderTypeException:
+      code: "C013"
+      message: "발신자 유형이 올바르지 않습니다."
+      status: 400
+
+    InvalidRoomStatusTransitionException:
+      code: "C014"
+      message: "채팅 방의 상태가 올바르지 않습니다."
+      status: 400

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,20 +4,13 @@ server:
 spring:
   application:
     name: chat-service
+  config:
+    import: 'optional:configserver: '
+  cloud:
+    discovery:
+      enabled: true
+      service-id: config-server
 
-  datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/chat_db}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: true
 
 eureka:
   client:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,9 +7,10 @@ spring:
   config:
     import: 'optional:configserver: '
   cloud:
-    discovery:
-      enabled: true
-      service-id: config-server
+    config:
+     discovery:
+        enabled: true
+        service-id: config-server
 
 
 eureka:

--- a/src/test/java/org/pgsg/chat/application/ChatServiceTest.java
+++ b/src/test/java/org/pgsg/chat/application/ChatServiceTest.java
@@ -1,0 +1,56 @@
+package org.pgsg.chat.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pgsg.chat.application.dto.CreateChatRoomCommand;
+import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.repository.ChatRoomRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+public class ChatServiceTest {
+
+    @Autowired
+    ChatService chatService;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Test
+    @DisplayName("채팅방 생성 테스트")
+    void create_room_test(){
+        // given
+        UUID tradeId = UUID.randomUUID();
+        CreateChatRoomCommand command = new CreateChatRoomCommand(
+                tradeId,
+                UUID.randomUUID(),
+                "판매 상품1",
+                UUID.randomUUID(),
+                "판매자 1",
+                UUID.randomUUID(),
+                "구매자 1"
+        );
+
+        // when
+        chatService.createRoom(command);
+        ChatRoom chatRoom = chatRoomRepository.findById(RoomId.of(tradeId))
+                .orElse(null);
+
+        // then
+        assertNotNull(chatRoom);
+        assertEquals(tradeId, chatRoom.getId().getId());
+        log.info("chatRoom={}", chatRoom);
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  cloud:
+    config:
+      enabled: false


### PR DESCRIPTION
### 작업 배경
- Chat 애그리거트 및 ChatMessage 구현

### 작업 내용
- Chat 예외 처리 부분을 공통 모듈에서 상속 받아 처리하였습니다.
- Chat 애그리거트의 VO, Enum 구현을 하였습니다.
- 공통 모듈 의존성 추가 하였습니다.
- gitignore에 generated에 관한 부분을 올라가지 않게 설정 추가하였습니다.
- 테스트 환경을 위해 H2를 사용하기 위해 Application.yaml파일을 추가하였습니다.

### 테스트 여부
- 채팅 방 생성 부분 테스트 코드를 작성하여 채팅 방 생성을 확인했습니다.

### 기타
- 추후 필요한 예외 처리는 ChatServiceException을 상속 받아 사용되는 ChatRoomNotFoundException와 같이 적용하여 명확성을 높이겠습니다.

### 이슈
- This closes #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 생성·메시지 추가·완료·취소 등 채팅방 관리 기능 추가
  * 판매자/구매자 정보 및 채팅 메시지 저장·조회 지원
  * 채팅 이벤트 콜백과 도메인 유효성 검사 도입

* **기타**
  * 일관된 클라이언트용 오류 매핑 구성 추가
  * 통합 테스트 추가 및 애플리케이션 설정·빌드 환경 개선(생성물 처리 포함)
  * VCS 무시 규칙에 생성물 디렉토리 제외 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->