### PR TITLE
[Feat] 채팅방 생성 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,java,gradle,intellij+all,visualstudiocode
 
 generated/
+src/main/resources/ssl/kafka.server.truststore.jks

--- a/src/main/java/org/pgsg/chat/ChatApplication.java
+++ b/src/main/java/org/pgsg/chat/ChatApplication.java
@@ -2,7 +2,6 @@ package org.pgsg.chat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class ChatApplication {

--- a/src/main/java/org/pgsg/chat/application/dto/CreateChatRoomCommand.java
+++ b/src/main/java/org/pgsg/chat/application/dto/CreateChatRoomCommand.java
@@ -1,0 +1,27 @@
+package org.pgsg.chat.application.dto;
+
+import org.pgsg.chat.domain.model.Room;
+
+import java.util.UUID;
+
+public record CreateChatRoomCommand(
+        UUID tradeId,
+        UUID productId,
+        String productName,
+        UUID sellerId,
+        String sellerNickName,
+        UUID buyerId,
+        String buyerNickName
+) {
+    public Room toChatRoom() {
+        return Room.builder()
+                .tradeId(tradeId)
+                .productId(productId)
+                .productName(productName)
+                .sellerId(sellerId)
+                .sellerNickName(sellerNickName)
+                .buyerId(buyerId)
+                .buyerNickName(buyerNickName)
+                .build();
+    }
+}

--- a/src/main/java/org/pgsg/chat/application/service/ChatService.java
+++ b/src/main/java/org/pgsg/chat/application/service/ChatService.java
@@ -1,0 +1,30 @@
+package org.pgsg.chat.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.pgsg.chat.application.dto.CreateChatRoomCommand;
+import org.pgsg.chat.domain.event.ChatEvents;
+import org.pgsg.chat.domain.exception.ChatRoomNotFoundException;
+import org.pgsg.chat.domain.model.Room;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.model.SenderType;
+import org.pgsg.chat.domain.repository.ChatRoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatEvents chatEvents;
+
+    // 채팅방 생성
+    @Transactional
+    public void createRoom(CreateChatRoomCommand dto) {
+        chatRoomRepository.save(dto.toChatRoom());
+    }
+
+   
+
+}

--- a/src/main/java/org/pgsg/chat/domain/event/ChatEvents.java
+++ b/src/main/java/org/pgsg/chat/domain/event/ChatEvents.java
@@ -1,8 +1,8 @@
 package org.pgsg.chat.domain.event;
 
-import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.Room;
 
 public interface ChatEvents {
-    void completed(ChatRoom room);
-    void canceled(ChatRoom room);
+    void completed(Room room);
+    void canceled(Room room);
 }

--- a/src/main/java/org/pgsg/chat/domain/model/Message.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Message.java
@@ -7,16 +7,15 @@ import lombok.RequiredArgsConstructor;
 import org.pgsg.chat.domain.exception.ChatServiceException;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "chat_message")
+@Table(name = "p_chat_message")
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-public class ChatMessage {
+public class Message {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,7 +34,7 @@ public class ChatMessage {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    public static ChatMessage of(SenderType type, String content) {
+    public static Message of(SenderType type, String content) {
         if (type ==null) {
             throw new ChatServiceException("InvalidSenderTypeException");
         }
@@ -43,9 +42,9 @@ public class ChatMessage {
         if (content == null || content.isBlank()) {
             throw new ChatServiceException("EmptyChatMessageException");
         }
-        ChatMessage chatMessage = new ChatMessage();
-        chatMessage.senderType = type;
-        chatMessage.content = content;
-        return chatMessage;
+        Message message = new Message();
+        message.senderType = type;
+        message.content = content;
+        return message;
     }
 }

--- a/src/main/java/org/pgsg/chat/domain/model/Room.java
+++ b/src/main/java/org/pgsg/chat/domain/model/Room.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Table(name = "p_chat_room")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
-public class ChatRoom extends BaseEntity {
+public class Room extends BaseEntity {
 
     @EmbeddedId
     private RoomId id;
@@ -39,10 +39,10 @@ public class ChatRoom extends BaseEntity {
     @JoinColumn(name="chatroom_id")
     @OrderBy("createdAt ASC")
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ChatMessage> messages = new ArrayList<>();
+    private List<Message> messages = new ArrayList<>();
 
     @Builder
-    public ChatRoom(UUID tradeId,UUID productId, String productName, UUID sellerId,String sellerNickName,UUID buyerId,String buyerNickName) {
+    public Room(UUID tradeId, UUID productId, String productName, UUID sellerId, String sellerNickName, UUID buyerId, String buyerNickName) {
         this.id = RoomId.of(tradeId);
         this.seller = new Seller(sellerId, sellerNickName);
         this.buyer = new Buyer(buyerId, buyerNickName);
@@ -55,7 +55,7 @@ public class ChatRoom extends BaseEntity {
         if(this.status != RoomStatus.TRADING){
             throw new ChatServiceException("InvalidRoomStatusTransitionException");
         }
-        this.messages.add(ChatMessage.of(type, content));
+        this.messages.add(Message.of(type, content));
     }
 
     // 마지막 메세지 등록 일시

--- a/src/main/java/org/pgsg/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/org/pgsg/chat/domain/repository/ChatRoomRepository.java
@@ -1,11 +1,11 @@
 package org.pgsg.chat.domain.repository;
 
-import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.Room;
 import org.pgsg.chat.domain.model.RoomId;
 
 import java.util.Optional;
 
 public interface ChatRoomRepository {
-    ChatRoom save(ChatRoom room);
-    Optional<ChatRoom> findById(RoomId id);
+    Room save(Room room);
+    Optional<Room> findById(RoomId id);
 }

--- a/src/main/java/org/pgsg/chat/infrastructure/event/ChatEventsImpl.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/event/ChatEventsImpl.java
@@ -1,18 +1,18 @@
 package org.pgsg.chat.infrastructure.event;
 
 import org.pgsg.chat.domain.event.ChatEvents;
-import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.Room;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ChatEventsImpl implements ChatEvents {
     @Override
-    public void completed(ChatRoom room) {
+    public void completed(Room room) {
 
     }
 
     @Override
-    public void canceled(ChatRoom room) {
+    public void canceled(Room room) {
 
     }
 }

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCreatedListener.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCreatedListener.java
@@ -1,0 +1,54 @@
+package org.pgsg.chat.infrastructure.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.chat.application.dto.CreateChatRoomCommand;
+import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.infrastructure.listener.dto.TradeCreated;
+import org.pgsg.common.messaging.annotation.IdempotentConsumer;
+import org.pgsg.common.util.JsonUtil;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeCreatedListener {
+
+    private final ChatService chatService;
+
+    @IdempotentConsumer("topics.trade.created")
+    @KafkaListener(topics = "${topics.trade.created}", groupId = "chat-service")
+    public void onTradeCreated(Message<String> message, Acknowledgment ack) {
+        try{
+            TradeCreated created = JsonUtil.fromJson(message.getPayload(), TradeCreated.class);
+
+            if (created != null) {
+                chatService.createRoom(new CreateChatRoomCommand(
+                        created.tradeId(),
+                        created.productId(),
+                        created.productName(),
+                        created.sellerId(),
+                        created.sellerNickName(),
+                        created.buyerId(),
+                        created.buyerNickName()
+                ));
+                
+                ack.acknowledge(); // 커밋 처리, 오프셋 기록
+                log.info("채팅방 생성 성공: RoomId: {}", created.tradeId());
+            }
+        } catch(Exception e) {
+            log.error("채팅방 생성 실패: {}", e.getMessage(),e);
+            throw e;
+        }
+    }
+
+    @KafkaListener(topics = "${topics.trade.created}-dlt", groupId = "chat-service")
+    public void handleDLT(Message<String> message, Acknowledgment ack) {
+        log.error("채팅방 생성 최종 실패(DLT), 수동 처리 요망");
+        // 수동 처리를 위한 DB기록 필요함.
+    }
+
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCreated.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCreated.java
@@ -1,0 +1,15 @@
+package org.pgsg.chat.infrastructure.listener.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TradeCreated(
+        UUID tradeId,
+        UUID productId,
+        String productName,
+        UUID sellerId,
+        String sellerNickName,
+        UUID buyerId,
+        String buyerNickName) { }

--- a/src/main/java/org/pgsg/chat/infrastructure/persistence/JpaChatRoomRepository.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/persistence/JpaChatRoomRepository.java
@@ -1,10 +1,10 @@
 package org.pgsg.chat.infrastructure.persistence;
 
-import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.Room;
 import org.pgsg.chat.domain.model.RoomId;
 import org.pgsg.chat.domain.repository.ChatRoomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaChatRoomRepository extends ChatRoomRepository, JpaRepository<ChatRoom, RoomId> {
+public interface JpaChatRoomRepository extends ChatRoomRepository, JpaRepository<Room, RoomId> {
 
 }

--- a/src/test/java/org/pgsg/chat/application/ChatServiceTest.java
+++ b/src/test/java/org/pgsg/chat/application/ChatServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.pgsg.chat.application.dto.CreateChatRoomCommand;
 import org.pgsg.chat.application.service.ChatService;
-import org.pgsg.chat.domain.model.ChatRoom;
+import org.pgsg.chat.domain.model.Room;
 import org.pgsg.chat.domain.model.RoomId;
 import org.pgsg.chat.domain.repository.ChatRoomRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,12 +45,12 @@ public class ChatServiceTest {
 
         // when
         chatService.createRoom(command);
-        ChatRoom chatRoom = chatRoomRepository.findById(RoomId.of(tradeId))
+        Room room = chatRoomRepository.findById(RoomId.of(tradeId))
                 .orElse(null);
 
         // then
-        assertNotNull(chatRoom);
-        assertEquals(tradeId, chatRoom.getId().getId());
-        log.info("chatRoom={}", chatRoom);
+        assertNotNull(room);
+        assertEquals(tradeId, room.getId().getId());
+        log.info("room={}", room);
     }
 }


### PR DESCRIPTION
### 작업 내용
- 거래 생성 이벤트 수신 로직 구현
- 이벤트 수신 시 자동으로 채팅방이 생성되는 로직 구현

### 테스트 여부
- UI for Apache kafka를 통해 거래 생성 이벤트를 발생시켜 채팅방이 생성되는 것을 확인하였습니다.

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #3
