### PR TITLE
[feat] complete와 cancel 로직 구현

### DIFF
--- a/src/main/java/org/pgsg/chat/application/service/ChatService.java
+++ b/src/main/java/org/pgsg/chat/application/service/ChatService.java
@@ -25,6 +25,21 @@ public class ChatService {
         chatRoomRepository.save(dto.toChatRoom());
     }
 
-   
+    // 거래 성공 처리
+    @Transactional
+    public void complete(UUID roomId){
+        getRoom(roomId).complete(chatEvents);
+    }
+
+    // 거래 취소 처리
+    @Transactional
+    public void cancel(UUID roomId){
+        getRoom(roomId).cancel(chatEvents);
+    }
+
+    private Room getRoom(UUID roomId){
+        return chatRoomRepository.findById(RoomId.of(roomId))
+                .orElseThrow(ChatRoomNotFoundException::new);
+    }
 
 }

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCanceledListener.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCanceledListener.java
@@ -1,0 +1,41 @@
+package org.pgsg.chat.infrastructure.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.infrastructure.listener.dto.TradeCanceled;
+import org.pgsg.common.messaging.annotation.IdempotentConsumer;
+import org.pgsg.common.util.JsonUtil;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeCanceledListener {
+    private final ChatService chatService;
+
+    @IdempotentConsumer("topics.trade.cancelled")
+    @KafkaListener(topics = "${topics.trade.cancelled}", groupId = "chat-service")
+    public void onCanceled(Message<String> message, Acknowledgment ack) {
+        TradeCanceled canceled = JsonUtil.fromJson(message.getPayload(), TradeCanceled.class);
+        try {
+            chatService.cancel(canceled.tradeId());
+            ack.acknowledge();
+
+            log.info("채팅 거래 취소 성공!! roomId: {}", canceled.tradeId());
+        } catch (Exception e){
+            log.error("채팅 거래 취소 처리 실패!!: {}, roomId: {}", e.getMessage(), canceled.tradeId(), e);
+            throw e;
+        }
+
+    }
+
+    @KafkaListener(topics = "${topics.trade.cancelled}-dlt", groupId = "chat-service")
+    public void handleDLT(Message<String> message, Acknowledgment ack) {
+        log.error("채팅 거래 취소 처리 최종 실패(DLT), 수동 처리 요망");
+        // 수동 처리를 위한 DB기록 필요함.
+    }
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCanceledListener.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCanceledListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pgsg.chat.application.service.ChatService;
 import org.pgsg.chat.infrastructure.listener.dto.TradeCanceled;
+import org.pgsg.common.exception.CustomException;
 import org.pgsg.common.messaging.annotation.IdempotentConsumer;
 import org.pgsg.common.util.JsonUtil;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -21,13 +22,16 @@ public class TradeCanceledListener {
     @KafkaListener(topics = "${topics.trade.cancelled}", groupId = "chat-service")
     public void onCanceled(Message<String> message, Acknowledgment ack) {
         TradeCanceled canceled = JsonUtil.fromJson(message.getPayload(), TradeCanceled.class);
+        if (canceled == null || canceled.tradeId() == null){
+            throw new CustomException("InvalidTradeIdException");
+        }
         try {
             chatService.cancel(canceled.tradeId());
             ack.acknowledge();
 
             log.info("채팅 거래 취소 성공!! roomId: {}", canceled.tradeId());
         } catch (Exception e){
-            log.error("채팅 거래 취소 처리 실패!!: {}, roomId: {}", e.getMessage(), canceled.tradeId(), e);
+            log.error("채팅 거래 취소 처리 실패!! payload={}", message.getPayload(), e);
             throw e;
         }
 

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCompletedListener.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCompletedListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pgsg.chat.application.service.ChatService;
 import org.pgsg.chat.infrastructure.listener.dto.TradeCompleted;
+import org.pgsg.common.exception.CustomException;
 import org.pgsg.common.messaging.annotation.IdempotentConsumer;
 import org.pgsg.common.util.JsonUtil;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -21,13 +22,16 @@ public class TradeCompletedListener {
     @KafkaListener(topics = "${topics.trade.completed}", groupId="chat-service")
     public void onCompleted(Message<String> message, Acknowledgment ack) {
         TradeCompleted completed = JsonUtil.fromJson(message.getPayload(), TradeCompleted.class);
+        if (completed == null || completed.tradeId() == null) {
+            throw new CustomException("InvalidTradeIdException");
+        }
         try {
             chatService.complete(completed.tradeId());
             ack.acknowledge();
 
             log.info("채팅 거래 완료처리 - roomId: {}", completed.tradeId());
         } catch (Exception e) {
-            log.error("채팅 거래 완료 처리 실패: {}, roomId: {}", e.getMessage(), completed.tradeId(), e);
+            log.error("채팅 거래 완료 처리 실패: payload={}", message.getPayload(), e);
             throw e;
         }
     }

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCompletedListener.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/TradeCompletedListener.java
@@ -1,0 +1,40 @@
+package org.pgsg.chat.infrastructure.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.infrastructure.listener.dto.TradeCompleted;
+import org.pgsg.common.messaging.annotation.IdempotentConsumer;
+import org.pgsg.common.util.JsonUtil;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeCompletedListener {
+    private final ChatService chatService;
+
+    @IdempotentConsumer("topics.trade.completed")
+    @KafkaListener(topics = "${topics.trade.completed}", groupId="chat-service")
+    public void onCompleted(Message<String> message, Acknowledgment ack) {
+        TradeCompleted completed = JsonUtil.fromJson(message.getPayload(), TradeCompleted.class);
+        try {
+            chatService.complete(completed.tradeId());
+            ack.acknowledge();
+
+            log.info("채팅 거래 완료처리 - roomId: {}", completed.tradeId());
+        } catch (Exception e) {
+            log.error("채팅 거래 완료 처리 실패: {}, roomId: {}", e.getMessage(), completed.tradeId(), e);
+            throw e;
+        }
+    }
+
+    @KafkaListener(topics = "${topics.trade.completed}-dlt", groupId="chat-service")
+    public void handleDLT(Message<String> message, Acknowledgment ack) {
+        log.error("채팅 거래 완료 처리 최종 실패(DLT), 수동 처리 요망");
+        // 수동 처리를 위한 DB 기록 필요!
+    }
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCanceled.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCanceled.java
@@ -1,7 +1,9 @@
 package org.pgsg.chat.infrastructure.listener.dto;
 
-import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.UUID;
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record TradeCanceled(
         UUID tradeId
 ) {

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCanceled.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCanceled.java
@@ -1,0 +1,8 @@
+package org.pgsg.chat.infrastructure.listener.dto;
+
+import java.util.UUID;
+
+public record TradeCanceled(
+        UUID tradeId
+) {
+}

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCompleted.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCompleted.java
@@ -1,0 +1,11 @@
+package org.pgsg.chat.infrastructure.listener.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TradeCompleted(
+        UUID tradeId
+) {
+}


### PR DESCRIPTION
### 작업 내용
- kafka 이벤트를 수신 받아 채팅방의 상태를 complete와 cancel로 상태 변경하는 로직 구현

### 테스트 여부
- kafka UI를 통해 생성된 채팅방의 상태가 거래 이벤트를 수신 받아 Complete와 Canceled로 변경되는 것을 확인했습니다.

### 이슈
- This closes #10 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 방에 대해 "완료" 및 "취소" 동작 추가
  * 거래 완료 이벤트 수신 시 채팅 상태 자동 처리 및 동기화
  * 거래 취소 이벤트 수신 시 채팅 상태 자동 처리 및 동기화
  * 장애(최종 실패) 발생 시 별도 로그로 수동 확인 안내
<!-- end of auto-generated comment: release notes by coderabbit.ai -->