### PR TITLE
feat: 채팅 메세지 전달 API  및 UI 구현

### DIFF
--- a/src/main/java/org/pgsg/chat/application/service/ChatService.java
+++ b/src/main/java/org/pgsg/chat/application/service/ChatService.java
@@ -37,6 +37,12 @@ public class ChatService {
         getRoom(roomId).cancel(chatEvents);
     }
 
+    // 채팅 대화 기록
+    @Transactional
+    public void addMessage(UUID roomId, String senderType, String message) {
+        getRoom(roomId).addMessage(SenderType.valueOf(senderType), message);
+    }
+
     private Room getRoom(UUID roomId){
         return chatRoomRepository.findById(RoomId.of(roomId))
                 .orElseThrow(ChatRoomNotFoundException::new);

--- a/src/main/java/org/pgsg/chat/presentiation/ChatController.java
+++ b/src/main/java/org/pgsg/chat/presentiation/ChatController.java
@@ -1,0 +1,28 @@
+package org.pgsg.chat.presentiation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.presentiation.dto.ChatRelay;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/{roomId}/message")
+    public void chatRelay(@DestinationVariable("roomId") UUID roomId, ChatRelay chatRelay) {
+        log.info("메세지 전송: roomId: {}, chatRelay: {}", roomId, chatRelay);
+        chatService.addMessage(roomId, chatRelay.type(), chatRelay.message());
+        messagingTemplate.convertAndSend("/topic/room/"+ roomId,chatRelay);
+        }
+    }

--- a/src/main/java/org/pgsg/chat/presentiation/dto/ChatRelay.java
+++ b/src/main/java/org/pgsg/chat/presentiation/dto/ChatRelay.java
@@ -1,0 +1,6 @@
+package org.pgsg.chat.presentiation.dto;
+
+public record ChatRelay(
+        String type,
+        String message
+) {}

--- a/src/main/resources/static/demo/chat.js
+++ b/src/main/resources/static/demo/chat.js
@@ -1,0 +1,113 @@
+let stompClient = null;
+// 임시 방 ID (실제 운영 시에는 이전 페이지에서 전달받아야 합니다)
+const ROOM_ID = "c2d7b183-ec25-4c1d-bc16-e8d698bdeebc";
+
+window.addEventListener("DOMContentLoaded", function() {
+    connectChat();
+});
+
+function connectChat() {
+    const socket = new SockJS("http://localhost:8084/chat");
+    stompClient = Stomp.over(socket);
+
+    // 콘솔 로그 간소화
+    stompClient.debug = null;
+
+    stompClient.connect({}, (frame) => {
+        console.log("연결 성공: " + frame);
+
+        // 백엔드 제안에 맞춰 수정된 방 번호 기반 토픽 구독
+        stompClient.subscribe(`/topic/room/${ROOM_ID}`, (response) => {
+            const data = JSON.parse(response.body);
+            displayMessage(data);
+        });
+    });
+}
+
+function sendMessage() {
+    const messageInput = document.getElementById("message-input");
+    const content = messageInput.value.trim();
+    const currentRole = document.getElementById("user-role").value; // BUYER or SELLER
+
+    if (content === "") return;
+
+    const payload = {
+        type: currentRole,
+        message: content
+    };
+
+    if (stompClient && stompClient.connected) {
+        stompClient.send(`/app/${ROOM_ID}/message`, {}, JSON.stringify(payload));
+        messageInput.value = "";
+    } else {
+        alert("채팅 서버와 연결되어 있지 않습니다.");
+    }
+}
+
+// 엔터키 입력 처리
+function handleKeyPress(event) {
+    if (event.key === "Enter") {
+        sendMessage();
+    }
+}
+
+// 수신한 메세지를 UI에 렌더링
+function displayMessage(data) {
+    const chatBox = document.getElementById("chat-box");
+    const currentRole = document.getElementById("user-role").value;
+
+    const messageDiv = document.createElement("div");
+    messageDiv.classList.add("message");
+
+    // 보낸 사람의 타입(BUYER/SELLER)이 현재 선택된 내 역할과 같으면 'mine', 다르면 'other'
+    if (data.type === currentRole) {
+        messageDiv.classList.add("mine");
+    } else {
+        messageDiv.classList.add("other");
+
+        // 상대방 메세지인 경우 발신자 표시
+        const senderSpan = document.createElement("span");
+        senderSpan.classList.add("message-sender");
+        senderSpan.textContent = data.type === "SELLER" ? "판매자" : "구매자";
+        messageDiv.appendChild(senderSpan);
+    }
+
+    const textNode = document.createTextNode(data.message);
+    messageDiv.appendChild(textNode);
+    chatBox.appendChild(messageDiv);
+
+    // 스크롤을 항상 최하단으로 이동
+    chatBox.scrollTop = chatBox.scrollHeight;
+}
+
+// 거래 상태 변경 처리 (완료 / 취소)
+function updateRoomStatus(status) {
+    let confirmMsg = status === 'COMPLETED' ? "거래를 완료하시겠습니까?" : "거래를 취소하고 채팅을 종료하시겠습니까?";
+
+    if(!confirm(confirmMsg)) return;
+
+    const endpoint = status === 'COMPLETED' ? 'complete' : 'cancel';
+
+    // 백엔드 제안 코드의 API 호출 (Fetch API 사용)
+    fetch(`http://localhost:8084/${ROOM_ID}/${endpoint}`, {
+        method: 'POST',
+    })
+        .then(response => {
+            if(response.ok) {
+                alert("처리되었습니다.");
+                // 지시사항 3, 4번에 따라 채팅 종료 처리
+                if (stompClient) stompClient.disconnect();
+                document.getElementById("message-input").disabled = true;
+
+                const chatBox = document.getElementById("chat-box");
+                const endMsg = document.createElement("div");
+                endMsg.classList.add("system-message");
+                endMsg.textContent = status === 'COMPLETED' ? "거래가 완료되어 채팅이 종료되었습니다." : "거래가 취소되어 채팅이 종료되었습니다.";
+                chatBox.appendChild(endMsg);
+                chatBox.scrollTop = chatBox.scrollHeight;
+            } else {
+                alert("처리 중 오류가 발생했습니다.");
+            }
+        })
+        .catch(error => console.error('Error:', error));
+}

--- a/src/main/resources/static/demo/index.html
+++ b/src/main/resources/static/demo/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>중고거래 채팅</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+<div class="chat-container">
+    <!-- 상단 헤더 및 액션 버튼 -->
+    <header class="chat-header">
+        <h2>중고거래 채팅</h2>
+        <div class="action-buttons">
+            <button onclick="updateRoomStatus('COMPLETED')" class="btn-complete">거래 완료</button>
+            <button onclick="updateRoomStatus('CANCELED')" class="btn-cancel">거래 취소</button>
+        </div>
+    </header>
+
+    <!-- 채팅 메시지 표시 영역 -->
+    <div id="chat-box" class="chat-box">
+        <div class="system-message">채팅방에 입장하셨습니다.</div>
+    </div>
+
+    <!-- 메시지 입력 영역 -->
+    <div class="chat-input-area">
+        <!-- 테스트용 역할 선택 -->
+        <select id="user-role" class="role-select">
+            <option value="BUYER">구매자 (나)</option>
+            <option value="SELLER">판매자 (나)</option>
+        </select>
+
+        <input type="text" id="message-input" placeholder="메시지를 입력하세요..." onkeypress="handleKeyPress(event)">
+        <button onclick="sendMessage()" class="btn-send">전송</button>
+    </div>
+</div>
+
+<script src="chat.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/demo/style.css
+++ b/src/main/resources/static/demo/style.css
@@ -1,0 +1,163 @@
+/* 전반적인 초기화 및 배경 설정 */
+body {
+    margin: 0;
+    padding: 20px;
+    background-color: #f0f4f8;
+    display: flex;
+    justify-content: center;
+    font-family: 'Malgun Gothic', sans-serif;
+}
+
+/* 채팅 컨테이너: 연한 하늘색 배경, 남색 테두리 */
+.chat-container {
+    width: 100%;
+    max-width: 450px;
+    height: 80vh;
+    background-color: #e0f7fa; /* 연한 하늘색 배경 */
+    border: 3px solid #001f3f; /* 남색 계열 주 색상 */
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+/* 헤더: 남색 배경, 흰색 글씨 */
+.chat-header {
+    background-color: #001f3f;
+    color: white;
+    padding: 15px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.chat-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+/* 상단 액션 버튼 */
+.action-buttons button {
+    padding: 8px 12px;
+    margin-left: 5px;
+    border: none;
+    border-radius: 6px;
+    font-weight: bold;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.btn-complete {
+    background-color: #4caf50;
+    color: white;
+}
+
+.btn-cancel {
+    background-color: #f44336;
+    color: white;
+}
+
+/* 채팅창 영역 */
+.chat-box {
+    flex: 1;
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+/* 시스템 메시지 */
+.system-message {
+    text-align: center;
+    color: #666;
+    font-size: 0.9rem;
+    margin: 10px 0;
+    background-color: rgba(255, 255, 255, 0.6);
+    border-radius: 12px;
+    padding: 5px;
+}
+
+/* 개별 메시지 공통 스타일 */
+.message {
+    max-width: 75%;
+    padding: 12px 16px;
+    border-radius: 20px;
+    font-size: 1rem;
+    line-height: 1.4;
+    word-break: break-word;
+}
+
+/* 내가 보낸 메시지 (남색) */
+.message.mine {
+    background-color: #001f3f;
+    color: white;
+    align-self: flex-end;
+    border-bottom-right-radius: 4px;
+}
+
+/* 상대방이 보낸 메시지 (흰색, 남색 테두리) */
+.message.other {
+    background-color: white;
+    color: #333;
+    border: 1px solid #001f3f;
+    align-self: flex-start;
+    border-bottom-left-radius: 4px;
+}
+
+.message-sender {
+    font-size: 0.8rem;
+    font-weight: bold;
+    margin-bottom: 4px;
+    color: #001f3f;
+    display: block;
+}
+
+.message.mine .message-sender {
+    display: none; /* 내 메시지에서는 보낸 사람 이름 숨김 */
+}
+
+/* 하단 입력 영역 */
+.chat-input-area {
+    display: flex;
+    padding: 15px;
+    background-color: white;
+    border-top: 2px solid #001f3f;
+    gap: 10px;
+}
+
+.role-select {
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 1rem;
+}
+
+#message-input {
+    flex: 1;
+    padding: 10px 15px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 1rem;
+    outline: none;
+}
+
+#message-input:focus {
+    border-color: #001f3f;
+}
+
+.btn-send {
+    background-color: #001f3f;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: bold;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.btn-send:hover {
+    background-color: #003366;
+}


### PR DESCRIPTION
### 작업 내용
- 채팅 컨트롤러로 endPoint를 통해 해당 룸에 채팅을 보내 소통하는 경로 구현.
- 테스트를 위해 UI를 간단하게 만들어서 채팅으로 소통 확인함.

### 테스트 여부
- 채팅 UI "localhost:8084/demo/index.html" 로 접속하여 채팅 UI를 통해 통신하는 테스트를 진행했습니다.
-  `./gradlew clean build -x test` 를 통해 빌드가 정상적으로 되는 것을 확인했습니다.

### 이슈
- This closes #13 
- This closes #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 실시간 채팅 메시징 기능 추가
  * 구매자/판매자 역할 선택이 가능한 채팅 인터페이스 구현
  * WebSocket 기반 양방향 메시지 송수신 지원
  * 거래 상태 업데이트 기능 (완료/취소) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->