### PR TITLE
[Feat] 채팅방 단건 조회 API 구현

### DIFF
--- a/src/main/java/org/pgsg/chat/application/dto/RoomInfo.java
+++ b/src/main/java/org/pgsg/chat/application/dto/RoomInfo.java
@@ -1,0 +1,32 @@
+package org.pgsg.chat.application.dto;
+
+import lombok.Builder;
+import org.pgsg.chat.domain.model.Room;
+import org.springframework.context.annotation.Bean;
+
+import java.util.UUID;
+
+@Builder
+public record RoomInfo(
+        UUID roomId,
+        UUID sellerId,
+        String sellerNickname,
+        UUID buyerId,
+        String buyerNickname,
+        UUID productId,
+        String productName,
+        String roomStatus
+) {
+    public static RoomInfo from(Room room) {
+        return RoomInfo.builder()
+                .roomId(room.getId().getId())
+                .sellerId(room.getSeller().getId())
+                .sellerNickname(room.getSeller().getNickname())
+                .buyerId(room.getBuyer().getId())
+                .buyerNickname(room.getBuyer().getNickname())
+                .productId(room.getProduct().getId())
+                .productName(room.getProduct().getName())
+                .roomStatus(room.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/org/pgsg/chat/application/service/query/ChatQueryService.java
+++ b/src/main/java/org/pgsg/chat/application/service/query/ChatQueryService.java
@@ -1,0 +1,30 @@
+package org.pgsg.chat.application.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.pgsg.chat.application.dto.RoomInfo;
+import org.pgsg.chat.domain.exception.ChatRoomNotFoundException;
+import org.pgsg.chat.domain.model.Room;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.repository.ChatRoomQueryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatQueryService {
+
+    private final ChatRoomQueryRepository roomQueryRepository;
+
+    // 단건 조회
+    public RoomInfo findChatRoom(UUID roomId){
+
+        Room room = roomQueryRepository.findById(RoomId.of(roomId))
+                .orElseThrow(ChatRoomNotFoundException::new);
+
+        return RoomInfo.from(room);
+    }
+    // 단체 조회
+}

--- a/src/main/java/org/pgsg/chat/domain/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/org/pgsg/chat/domain/repository/ChatRoomQueryRepository.java
@@ -1,0 +1,13 @@
+package org.pgsg.chat.domain.repository;
+
+import org.pgsg.chat.domain.model.Room;
+import org.pgsg.chat.domain.model.RoomId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface ChatRoomQueryRepository {
+    Optional<Room> findById(RoomId roomId);
+    Page<Room> findAll(ChatRoomSearch search, Pageable pageable);
+}

--- a/src/main/java/org/pgsg/chat/domain/repository/ChatRoomSearch.java
+++ b/src/main/java/org/pgsg/chat/domain/repository/ChatRoomSearch.java
@@ -1,0 +1,16 @@
+package org.pgsg.chat.domain.repository;
+
+import lombok.Builder;
+import org.pgsg.chat.domain.model.RoomId;
+
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+public record ChatRoomSearch(
+    List<RoomId> roomIds,
+    List<UUID> userIds,
+    String productName, // 상품명
+    String userName, //사용자명
+    String keyword // 상품명 + 사용자명 키워드 조회
+) {}

--- a/src/main/java/org/pgsg/chat/infrastructure/persistence/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/persistence/ChatRoomQueryRepositoryImpl.java
@@ -1,0 +1,92 @@
+package org.pgsg.chat.infrastructure.persistence;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.pgsg.chat.domain.model.Room;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.repository.ChatRoomQueryRepository;
+import org.pgsg.chat.domain.repository.ChatRoomSearch;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.pgsg.chat.domain.model.QRoom.room;
+
+
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Room> findById(RoomId roomId) {
+
+        Room result = queryFactory.selectFrom(room)
+                .where(
+                        room.id.eq(roomId),
+                        room.deletedAt.isNull()
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Page<Room> findAll(ChatRoomSearch search, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(room.deletedAt.isNull());
+
+        if(search.roomIds() != null) { // 방 ID 여러개 검색
+            builder.and(room.id.in(search.roomIds()));
+        }
+
+        if(search.userIds() != null) {
+            builder.and(
+                    room.buyer.id.in(search.userIds())
+                            .or(room.seller.id.in(search.userIds()))
+            );
+        }
+
+        if(StringUtils.hasText(search.productName())){ // 상품명이 있을 때
+            builder.and(room.product.name.contains(search.productName().trim())
+            );
+        }
+
+        if(StringUtils.hasText(search.userName())){
+            builder.and(room.buyer.nickname.contains(search.userName().trim())
+                    .or(room.seller.nickname.contains(search.userName().trim()))
+            );
+        }
+
+        if(StringUtils.hasText(search.keyword())){  //키워드 조회 : 상품명 or 사용자명
+            builder.and(
+                    room.product.name.contains(search.keyword().trim())
+                            .or(room.seller.nickname.contains(search.keyword().trim()))
+                            .or(room.buyer.nickname.contains(search.keyword().trim()))
+            );
+        }
+
+        List<Room> items = queryFactory
+                .selectFrom(room)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(room.createdAt.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(room.count())
+                .from(room)
+                .where(builder);
+
+        return PageableExecutionUtils.getPage(items,pageable,countQuery::fetchCount);
+    }
+}

--- a/src/main/java/org/pgsg/chat/presentiation/ChatController.java
+++ b/src/main/java/org/pgsg/chat/presentiation/ChatController.java
@@ -2,27 +2,43 @@ package org.pgsg.chat.presentiation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.pgsg.chat.application.dto.RoomInfo;
 import org.pgsg.chat.application.service.ChatService;
+import org.pgsg.chat.application.service.query.ChatQueryService;
 import org.pgsg.chat.presentiation.dto.ChatRelay;
+import org.pgsg.chat.presentiation.dto.FindRoomResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
 @Slf4j
 @RestController
+@RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
 public class ChatController {
 
     private final ChatService chatService;
+    private final ChatQueryService chatQueryService;
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/{roomId}/message")
     public void chatRelay(@DestinationVariable("roomId") UUID roomId, ChatRelay chatRelay) {
         log.info("메세지 전송: roomId: {}, chatRelay: {}", roomId, chatRelay);
         chatService.addMessage(roomId, chatRelay.type(), chatRelay.message());
-        messagingTemplate.convertAndSend("/topic/room/"+ roomId,chatRelay);
-        }
+        messagingTemplate.convertAndSend("/topic/room/" + roomId, chatRelay);
     }
+
+    @GetMapping("/rooms/{roomId}")
+    public ResponseEntity<FindRoomResponse> findRoom(@PathVariable("roomId") UUID roomId){
+        FindRoomResponse response = FindRoomResponse.from(chatQueryService.findChatRoom(roomId));
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/org/pgsg/chat/presentiation/dto/FindRoomResponse.java
+++ b/src/main/java/org/pgsg/chat/presentiation/dto/FindRoomResponse.java
@@ -1,0 +1,31 @@
+package org.pgsg.chat.presentiation.dto;
+
+import lombok.Builder;
+import org.pgsg.chat.application.dto.RoomInfo;
+
+import java.util.UUID;
+
+@Builder
+public record FindRoomResponse(
+        UUID roomId,
+        UUID sellerId,
+        String sellerNickname,
+        UUID buyerId,
+        String buyerNickname,
+        UUID productId,
+        String productName,
+        String roomStatus
+) {
+    public static FindRoomResponse from(RoomInfo roomInfo) {
+        return FindRoomResponse.builder()
+                .roomId(roomInfo.roomId())
+                .sellerId(roomInfo.sellerId())
+                .sellerNickname(roomInfo.sellerNickname())
+                .buyerId(roomInfo.buyerId())
+                .buyerNickname(roomInfo.buyerNickname())
+                .productId(roomInfo.productId())
+                .productName(roomInfo.productName())
+                .roomStatus(roomInfo.roomStatus())
+                .build();
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 채팅 방의 id를 가지고 해당 채팅 방의 정보를 찾아오는 Read 구현했습니다.
- 해당 기술은 ReadOnly로 기본 Repository인 CRUDRepository가 아닌 DB조회에 강점인 QueryRepository 기술을 채택하였습니다.

### 테스트 여부
- ./gradlew clean build -x test로 정상 빌드 되는 것을 확인했습니다.
- postman으로 `/api/v1/chat/rooms/{roomId}`를 통해 해당 방의 정보를 가져오는 것을 확인했습니다.

### 이슈

- This closes #6 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅방 정보를 조회하는 새로운 API 엔드포인트 추가: `GET /api/v1/chat/rooms/{roomId}`를 통해 방 ID로 판매자, 구매자, 상품명 등 채팅방의 세부 정보를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->