### PR TITLE
[Feat] 채팅방 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/pgsg/chat/application/dto/FindChatRoomQuery.java
+++ b/src/main/java/org/pgsg/chat/application/dto/FindChatRoomQuery.java
@@ -1,0 +1,38 @@
+package org.pgsg.chat.application.dto;
+
+import lombok.Builder;
+import org.pgsg.chat.domain.model.RoomId;
+import org.pgsg.chat.domain.repository.ChatRoomSearch;
+
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+public record FindChatRoomQuery(
+        List<RoomId> roomIds,
+        List<UUID> userIds,
+        String productName, // 상품명
+        String userName, //사용자명
+        String keyword
+) {
+
+    public static ChatRoomSearch toSearch(FindChatRoomQuery query) {
+        return ChatRoomSearch.builder()
+                .roomIds(query.roomIds())
+                .userIds(query.userIds())
+                .productName(query.productName())
+                .userName(query.userName())
+                .keyword(query.keyword())
+                .build();
+    }
+
+    public static FindChatRoomQuery of(List<UUID> userIds, String productName, String userName, String keyword) {
+        return FindChatRoomQuery.builder()
+                .userIds(userIds)
+                .productName(productName)
+                .userName(userName)
+                .keyword(keyword)
+                .build();
+    }
+
+}

--- a/src/main/java/org/pgsg/chat/application/dto/RoomInfo.java
+++ b/src/main/java/org/pgsg/chat/application/dto/RoomInfo.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import org.pgsg.chat.domain.model.Room;
 import org.springframework.context.annotation.Bean;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
@@ -15,7 +16,9 @@ public record RoomInfo(
         String buyerNickname,
         UUID productId,
         String productName,
-        String roomStatus
+        String roomStatus,
+        LocalDateTime lastMessageAt,
+        String lastMessage
 ) {
     public static RoomInfo from(Room room) {
         return RoomInfo.builder()
@@ -27,6 +30,8 @@ public record RoomInfo(
                 .productId(room.getProduct().getId())
                 .productName(room.getProduct().getName())
                 .roomStatus(room.getStatus().name())
+                .lastMessageAt(room.getLastMessageAt())
+                .lastMessage(room.getMessages().isEmpty() ? null : room.getMessages().getLast().getContent())
                 .build();
     }
 }

--- a/src/main/java/org/pgsg/chat/application/service/query/ChatQueryService.java
+++ b/src/main/java/org/pgsg/chat/application/service/query/ChatQueryService.java
@@ -1,11 +1,14 @@
 package org.pgsg.chat.application.service.query;
 
 import lombok.RequiredArgsConstructor;
+import org.pgsg.chat.application.dto.FindChatRoomQuery;
 import org.pgsg.chat.application.dto.RoomInfo;
 import org.pgsg.chat.domain.exception.ChatRoomNotFoundException;
 import org.pgsg.chat.domain.model.Room;
 import org.pgsg.chat.domain.model.RoomId;
 import org.pgsg.chat.domain.repository.ChatRoomQueryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,5 +29,10 @@ public class ChatQueryService {
 
         return RoomInfo.from(room);
     }
+
     // 단체 조회
+    public Page<RoomInfo> findChatRooms(FindChatRoomQuery query,  Pageable pageable){
+        return roomQueryRepository.findAll(FindChatRoomQuery.toSearch(query),pageable).map(RoomInfo::from);
+    }
+
 }

--- a/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCreated.java
+++ b/src/main/java/org/pgsg/chat/infrastructure/listener/dto/TradeCreated.java
@@ -1,6 +1,7 @@
 package org.pgsg.chat.infrastructure.listener.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.UUID;
 
@@ -10,6 +11,8 @@ public record TradeCreated(
         UUID productId,
         String productName,
         UUID sellerId,
+        @JsonProperty("sellerNickName")
         String sellerNickname,
         UUID buyerId,
+        @JsonProperty("buyerNickName")
         String buyerNickname) { }

--- a/src/main/java/org/pgsg/chat/presentiation/ChatController.java
+++ b/src/main/java/org/pgsg/chat/presentiation/ChatController.java
@@ -2,20 +2,21 @@ package org.pgsg.chat.presentiation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.pgsg.chat.application.dto.RoomInfo;
+import org.pgsg.chat.application.dto.FindChatRoomQuery;
 import org.pgsg.chat.application.service.ChatService;
 import org.pgsg.chat.application.service.query.ChatQueryService;
 import org.pgsg.chat.presentiation.dto.ChatRelay;
 import org.pgsg.chat.presentiation.dto.FindRoomResponse;
+import org.pgsg.chat.presentiation.dto.ListRoomResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -38,6 +39,19 @@ public class ChatController {
     @GetMapping("/rooms/{roomId}")
     public ResponseEntity<FindRoomResponse> findRoom(@PathVariable("roomId") UUID roomId){
         FindRoomResponse response = FindRoomResponse.from(chatQueryService.findChatRoom(roomId));
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/rooms")
+    public ResponseEntity<Page<ListRoomResponse>> findRooms(
+            @RequestParam(required = false)List<UUID> userIds,
+            @RequestParam(required = false) String productName,
+            @RequestParam(required = false) String userName,
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+            ){
+        Page<ListRoomResponse> response = chatQueryService.findChatRooms(FindChatRoomQuery.of(userIds, productName,userName,keyword),pageable).map(ListRoomResponse::from);
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/pgsg/chat/presentiation/dto/FindRoomResponse.java
+++ b/src/main/java/org/pgsg/chat/presentiation/dto/FindRoomResponse.java
@@ -3,6 +3,7 @@ package org.pgsg.chat.presentiation.dto;
 import lombok.Builder;
 import org.pgsg.chat.application.dto.RoomInfo;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
@@ -14,7 +15,9 @@ public record FindRoomResponse(
         String buyerNickname,
         UUID productId,
         String productName,
-        String roomStatus
+        String roomStatus,
+        LocalDateTime lastMessageAt,
+        String lastMessage
 ) {
     public static FindRoomResponse from(RoomInfo roomInfo) {
         return FindRoomResponse.builder()
@@ -26,6 +29,8 @@ public record FindRoomResponse(
                 .productId(roomInfo.productId())
                 .productName(roomInfo.productName())
                 .roomStatus(roomInfo.roomStatus())
+                .lastMessageAt(roomInfo.lastMessageAt())
+                .lastMessage(roomInfo.lastMessage())
                 .build();
     }
 }

--- a/src/main/java/org/pgsg/chat/presentiation/dto/ListRoomResponse.java
+++ b/src/main/java/org/pgsg/chat/presentiation/dto/ListRoomResponse.java
@@ -1,0 +1,30 @@
+package org.pgsg.chat.presentiation.dto;
+
+import lombok.Builder;
+import org.pgsg.chat.application.dto.RoomInfo;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ListRoomResponse(
+        UUID roomId,
+        String productName,
+        String sellerNickname,
+        String buyerNickname,
+        String roomStatus,
+        LocalDateTime lastMessageAt,
+        String lastMessage
+) {
+    public static ListRoomResponse from(RoomInfo roomInfo) {
+        return ListRoomResponse.builder()
+                .roomId(roomInfo.roomId())
+                .productName(roomInfo.productName())
+                .sellerNickname(roomInfo.sellerNickname())
+                .buyerNickname(roomInfo.buyerNickname())
+                .roomStatus(roomInfo.roomStatus())
+                .lastMessageAt(roomInfo.lastMessageAt())
+                .lastMessage(roomInfo.lastMessage())
+                .build();
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 채팅 방 목록 조회 API 구현했습니다.
- 단건 목록 조회에서도 마지막 채팅과 채팅 시간을 저장하는 필드를 추가했습니다.
- 이전 거래에서 이벤트 발신 시 컬럼 네임이 맞지 않아 채팅 방이 생성 되지 않는 오류를 수정했습니다.

### 테스트 여부
- ./gradlew clean build -x test 로 빌드가 정상 작동하는 것을 확인했습니다.
- postman으로 /api/v1/chat/rooms로 채팅 방들의 데이터가 넘어오는 것을 확인했습니다.

### 이슈
- This closes #14 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 검색 및 목록 조회 기능이 추가되었습니다.
  * 사용자 ID, 상품명, 사용자명, 키워드를 통해 채팅방을 검색할 수 있습니다.
  * 각 채팅방의 최신 메시지 타임스탐프와 메시지 내용을 확인할 수 있습니다.
  * 페이지네이션 지원으로 대량의 채팅방을 효율적으로 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->